### PR TITLE
Preliminary server support

### DIFF
--- a/src/server/ChronoTimerWebClient.java
+++ b/src/server/ChronoTimerWebClient.java
@@ -1,0 +1,14 @@
+package server;
+
+import core.Chronotimer;
+
+/*
+ * An addon class for connecting the Chronotimer to a http web server.
+ */
+public class ChronoTimerWebClient {
+	private Chronotimer chronoTimer = null;
+	public ChronoTimerWebClient(Chronotimer timer) {
+		if (timer == null) throw new IllegalArgumentException("timer");
+		chronoTimer = timer;
+	}
+}

--- a/src/server/ChronoTimerWebClient.java
+++ b/src/server/ChronoTimerWebClient.java
@@ -1,6 +1,12 @@
 package server;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
 import core.Chronotimer;
+import core.Chronotimer.RaceStatusChangedEventType;
+import core.Racer;
+import core.Run;
 
 /*
  * An addon class for connecting the Chronotimer to a http web server.
@@ -10,5 +16,25 @@ public class ChronoTimerWebClient {
 	public ChronoTimerWebClient(Chronotimer timer) {
 		if (timer == null) throw new IllegalArgumentException("timer");
 		chronoTimer = timer;
+		
+		//event handler for listening for when a race starts and ends.
+		timer.addRaceStatusChangedActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				Chronotimer.RaceStatusChangedEventType raceType = Enum.valueOf(Chronotimer.RaceStatusChangedEventType.class, e.getActionCommand());
+				
+				//check to see if this handler is being fired because a race ended.
+				if (raceType == RaceStatusChangedEventType.RaceEnd) {
+					//grab the current race so that we can get the results (finished racers).
+					Run currentRun = timer.getCurrentRun();
+					if (currentRun != null) {
+						//get the finished racers
+						Racer[] raceResults = currentRun.getFinishedRacers();
+						
+						//todo prepare to send it to the server.
+					}
+				}
+			}
+		});
 	}
 }

--- a/src/server/ChronoTimerWebServer.java
+++ b/src/server/ChronoTimerWebServer.java
@@ -62,6 +62,9 @@ public class ChronoTimerWebServer {
     			
     			//deserialize response (assuming it is json) into an object using the Gson lib.
     			
+    			//http status code 201 "created"
+    			t.sendResponseHeaders(201, -1);
+    			
     		} else {
     			//http status code 501 "not implemented"
     			//https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/com/sun/net/httpserver/HttpExchange.html#sendResponseHeaders-int-long-

--- a/src/server/ChronoTimerWebServer.java
+++ b/src/server/ChronoTimerWebServer.java
@@ -1,0 +1,48 @@
+package server;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import core.Chronotimer;
+
+public class ChronoTimerWebServer {
+	private static boolean isInitialized = false;
+	private static Chronotimer serverTimer = null;
+	private static HttpServer httpServer = null;
+	
+	public static void initialize(Chronotimer chronoTimer) throws IOException {
+		if (isInitialized) return;
+		if (chronoTimer == null) throw new IllegalArgumentException("chronoTimer");
+		serverTimer = chronoTimer;
+		
+		httpServer = HttpServer.create(new InetSocketAddress(8000), 0);
+		
+        // create a context to get the request to display the results
+		httpServer.createContext("/", new IndexHandler());
+        //server.createContext("/style.css", new StyleHandler());
+
+		httpServer.setExecutor(null); // creates a default executor
+		
+		httpServer.start();
+		isInitialized = true;
+	}
+	
+    static class IndexHandler implements HttpHandler {
+        public void handle(HttpExchange t) throws IOException {
+            // write out the response
+        	String html = "<html><head><title>ChronoTimer</title></head><body><p>Index page.</p></body></html>";
+
+            t.sendResponseHeaders(200, html.length());
+
+            OutputStream os = t.getResponseBody();
+            os.write(html.getBytes());
+            os.close();
+        }
+
+    }
+}

--- a/src/server/ChronoTimerWebServer.java
+++ b/src/server/ChronoTimerWebServer.java
@@ -1,9 +1,11 @@
 package server;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 
+import com.google.gson.Gson;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -12,23 +14,28 @@ import core.Chronotimer;
 
 public class ChronoTimerWebServer {
 	private static boolean isInitialized = false;
-	private static Chronotimer serverTimer = null;
 	private static HttpServer httpServer = null;
+	private static HttpServer chronoServer = null;
 	
-	public static void initialize(Chronotimer chronoTimer) throws IOException {
+	public static void main(String[] args) throws IOException {
+		System.out.print("Initializing server... ");
+		initialize();
+		System.out.println("Done");
+	}
+	
+	public static void initialize() throws IOException {
 		if (isInitialized) return;
-		if (chronoTimer == null) throw new IllegalArgumentException("chronoTimer");
-		serverTimer = chronoTimer;
 		
+		//create a http server for browsers.
 		httpServer = HttpServer.create(new InetSocketAddress(8000), 0);
-		
-        // create a context to get the request to display the results
 		httpServer.createContext("/", new IndexHandler());
-        //server.createContext("/style.css", new StyleHandler());
-
-		httpServer.setExecutor(null); // creates a default executor
-		
 		httpServer.start();
+		
+		//create a http server specifically for the chronotimer to connect to.
+		chronoServer = HttpServer.create(new InetSocketAddress(8080), 0);
+		chronoServer.createContext("/display", new ChronoTimerPostHandler());
+		chronoServer.start();
+		
 		isInitialized = true;
 	}
 	
@@ -43,6 +50,41 @@ public class ChronoTimerWebServer {
             os.write(html.getBytes());
             os.close();
         }
+    }
+    
+    static class ChronoTimerPostHandler implements HttpHandler {
+    	public void handle(HttpExchange t) throws IOException {
+    		if (t.getRequestMethod() == "POST" || t.getRequestMethod() == "PUT") {
+    			//handle the post.
+    			Gson g = new Gson();
+    			//grab the response string from the request
+    			String response = readResponseAsString(t);
+    			
+    			//deserialize response (assuming it is json) into an object using the Gson lib.
+    			
+    		} else {
+    			//http status code 501 "not implemented"
+    			//https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/com/sun/net/httpserver/HttpExchange.html#sendResponseHeaders-int-long-
+    			t.sendResponseHeaders(501, -1);
+    		}
+    		t.close();
+    	}
+    	
+    	private String readResponseAsString(HttpExchange transmission) throws IOException {
+    		// set up a stream to read the body of the request
+            InputStream inputStr = transmission.getRequestBody();
 
+            // string to hold the result of reading in the request
+            StringBuilder sb = new StringBuilder();
+
+            // read the characters from the request byte by byte
+            int nextChar = inputStr.read();
+            while (nextChar > -1) {
+                sb=sb.append((char)nextChar);
+                nextChar=inputStr.read();
+            }
+           
+            return sb.toString();
+    	}
     }
 }


### PR DESCRIPTION
This pull request implements the groundwork for the server feature of the ChronoTimer. This will allow for completing #61 much easier.

This pull request adds hooks into the ChronoTimer that exposes when a race was created and when it has ended.

The server component has two http servers running simultaneously: one is running on port 8000 for browsers, the other is on port 8080 specifically for the ChronoTimer.

The http client for the ChronoTimer (which allows it to connect to the server) is implemented as an add-on/wrapper to minimize the work needed to be done on the ChronoTimer itself. 